### PR TITLE
updated repository name to the newer one for mason and mason-lspconfig

### DIFF
--- a/config/init.lua
+++ b/config/init.lua
@@ -50,7 +50,7 @@ vim.opt.clipboard = "unnamedplus"
 
 -- Leader key
 vim.g.mapleader = " "
-vim.g.maplocalleader = " "
+vim.g.maplocalleader = "\\"
 
 -- Bootstrap lazy.nvim
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
@@ -191,8 +191,8 @@ require("lazy").setup({
   {
     "neovim/nvim-lspconfig",
     dependencies = {
-      "williamboman/mason.nvim",
-      "williamboman/mason-lspconfig.nvim",
+      "mason-org/mason.nvim",
+      "mason-org/mason-lspconfig.nvim",
     },
     config = function()
       require("mason").setup()


### PR DESCRIPTION
Updated the repo name for mason


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Refactor
  - Changed the default local leader key to backslash (\), affecting how local key mappings are triggered.

- Chores
  - Updated LSP tooling dependencies to their new official namespace to ensure ongoing compatibility and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->